### PR TITLE
Bugfix: last thread quit and x86_64 module

### DIFF
--- a/kernel/src/trap.rs
+++ b/kernel/src/trap.rs
@@ -22,7 +22,18 @@ pub fn error(tf: &TrapFrame) -> ! {
     error!("{:#x?}", tf);
     let tid = processor().tid();
     error!("On CPU{} Thread {}", cpu::id(), tid);
-
+    let thread = unsafe { current_thread() };
+    let mut proc=thread.proc.lock();
+    proc.threads.retain(|&id| id != tid);
+    if proc.threads.len()==0 {
+        proc.exit(0x100);
+    }    
+    drop(proc);
+    // TODO: futex wait, and make sure that no dangerous operation here.
+    //  A better approach would be using a real signal...
+    //  But I'm not inventing the world again.
+    //  Anyway, you can emulate a signal receiver, and every thread kills itself when it receives a signal.
+    //  At least this is a bit better than any cross-thread killing.
     processor().manager().exit(tid, 0x100);
     processor().yield_now();
     unreachable!();

--- a/modules/hello_rust/build.rs
+++ b/modules/hello_rust/build.rs
@@ -3,4 +3,6 @@ fn main() {
     println!("cargo:rustc-link-search=all={}", path);
     let path = "../../kernel/target/aarch64/release/deps";
     println!("cargo:rustc-link-search=all={}", path);
+    let path = "../../kernel/target/release/deps";
+    println!("cargo:rustc-link-search=all={}", path);
 }

--- a/modules/hello_rust/build.sh
+++ b/modules/hello_rust/build.sh
@@ -31,7 +31,8 @@ rustc --edition=2018 --crate-name hello_rust src/lib.rs \
 -L dependency=target/$ARCH/release/deps \
 -L dependency=target/release/deps \
 --emit=obj --sysroot target/sysroot \
--L all=../../kernel/target/$ARCH/release/deps
+-L all=../../kernel/target/$ARCH/release/deps \
+-L all=../../kernel/target/release/deps
 echo "Step 3. Packing the library into kernel module."
 "$PREFIX"objcopy --input binary --output $TEXT_TYPE \
     --binary-architecture $BIN_ARCH\


### PR DESCRIPTION
1. x86_64 kernel module build

问题在于Rust引进了一种新的`proc-macro`连接方式：这种链接方式的中间产物会放在target/release/deps下（应该是平台无关的）
直接把这个目录拉进build.sh和build.rs，解决

2. Last thread quitting bug

```
最后一个线程挂掉不会使得程序退出
这bug好像已经被修过了
不过针对同一个bug的两个patch竟然没有conflict
```